### PR TITLE
Added PHP Path in Plesk

### DIFF
--- a/other/phpcommand.php
+++ b/other/phpcommand.php
@@ -12,4 +12,5 @@ $phpcommand = "php";
 #$phpcommand = "C:\PHP7\php.exe";
 #$phpcommand = "\"C:\Program Files (x86)\PHP\php.exe\"";  // on blanks you need special marks \"
 #$phpcommand = "c:\wamp\bin\php\php.exe";
+#$phpcommand = "/opt/plesk/php/<PHP version>/bin/php"
 ?>


### PR DESCRIPTION
I added the Path from PHP in Plesk. It is not the "OS Vendor"-Version. It is the path of the multiple versions which can be installed in plesk. So the user must set the Version correctly.
Example Path for PHP 7.2
`/opt/plesk/php/7.2/bin/php`