### PR TITLE
Fix reflected XSS in list_rankup.php

### DIFF
--- a/stats/list_rankup.php
+++ b/stats/list_rankup.php
@@ -144,6 +144,8 @@ if(!isset($_GET["user"])) {
 	$user_pro_seite = preg_replace('/\D/', '', $_GET["user"]);
 }
 
+$getstring = htmlspecialchars($getstring);
+
 $start = ($seite * $user_pro_seite) - $user_pro_seite;
 
 if ($keysort == 'active' && $keyorder == 'asc') {


### PR DESCRIPTION
Bzgl. #464 
Hier ein möglicher Fix.

```php
$getstring = $_GET['search']; 
// ... Verarbeitung ...
$getstring = htmlspecialchars($getstring);
// ...
echo '&amp;search=' . $getstring;
```

Kann natürlich auch so gemacht werden:
```php
$getstring = htmlspecialchars($_GET['search']); 
```
Hab aber nicht durchgelesen, was deine Verarbeitung mit der Variable so anstellt. Deshalb einfach kurz vor die Ausgabe gepackt.