### PR TITLE
Fix reflected XSS in list_rankup.php

### DIFF
--- a/stats/list_rankup.php
+++ b/stats/list_rankup.php
@@ -144,6 +144,8 @@ if(!isset($_GET["user"])) {
 	$user_pro_seite = preg_replace('/\D/', '', $_GET["user"]);
 }
 
+$getstring = htmlspecialchars($getstring);
+
 $start = ($seite * $user_pro_seite) - $user_pro_seite;
 
 if ($keysort == 'active' && $keyorder == 'asc') {

--- a/stats/list_rankup.php
+++ b/stats/list_rankup.php
@@ -28,8 +28,9 @@ if(!isset($_SESSION[$rspathhex.'tsuid'])) {
 	set_session_ts3($ts['voice'], $mysqlcon, $dbname, $language, $adminuuid);
 }
 
+$_GET["search"] = htmlspecialchars($_POST['usersuche']);
+
 if(isset($_POST['username'])) {
-	$_GET["search"] = strip_tags(htmlspecialchars($_POST['usersuche']));
 	$_GET["seite"] = 1;
 }
 $filter='';
@@ -143,8 +144,6 @@ if(!isset($_GET["user"])) {
 } else {
 	$user_pro_seite = preg_replace('/\D/', '', $_GET["user"]);
 }
-
-$getstring = htmlspecialchars($getstring);
 
 $start = ($seite * $user_pro_seite) - $user_pro_seite;
 

--- a/stats/list_rankup.php
+++ b/stats/list_rankup.php
@@ -28,15 +28,14 @@ if(!isset($_SESSION[$rspathhex.'tsuid'])) {
 	set_session_ts3($ts['voice'], $mysqlcon, $dbname, $language, $adminuuid);
 }
 
-$_GET["search"] = htmlspecialchars($_POST['usersuche']);
-
 if(isset($_POST['username'])) {
 	$_GET["seite"] = 1;
+	$_GET["search"] = $_POST['usersuche'];
 }
 $filter='';
 $searchstring='';
 if(isset($_GET["search"]) && $_GET["search"] != '') {
-	$getstring = $_GET['search'];
+	$getstring = htmlspecialchars($_GET['search']);
 }
 if(isset($getstring) && strstr($getstring, 'filter:excepted:')) {
 	if(str_replace('filter:excepted:','',$getstring)!='') {


### PR DESCRIPTION
Re: #464 
So hier nochmal an der richtigen Stelle.
Das ` strip_tags()` hab ich weggelassen, da es überflüssig ist. Falls es dich interessiert hier mal eine Beispielausgabe mit verschiedenen Varianten:
```php
$code = '<script src="foobar">alert("Hallo Welt!");</script>';
echo 'A:'  . $code . "\n";
echo 'B: ' . htmlspecialchars($code) . "\n";
echo 'C: ' . strip_tags(htmlspecialchars($code)) . "\n";
echo 'D: ' . strip_tags($code) . "\n";
```
```
A: <script src="foobar">alert("Hallo Welt!");</script>
B: &lt;script src=&quot;foobar&quot;&gt;alert(&quot;Hallo Welt!&quot;);&lt;/script&gt;
C: &lt;script src=&quot;foobar&quot;&gt;alert(&quot;Hallo Welt!&quot;);&lt;/script&gt;
D: alert("Hallo Welt!");
```