### PR TITLE
CSRF Protection Implementation

### DIFF
--- a/other/csrf_handler.php
+++ b/other/csrf_handler.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file provides a valid $CSRF form field for the application
+ * to embed in HTML forms upon GET requests.
+ * On POSTs it validates the token, which is stored
+ * in the $_SESSION variable
+ * 
+ * Example usage:
+ *   require_once('../other/csrf_handler.php');
+ *   ...
+ *   <form method="POST">
+ *     <?php echo $CSRF; ?>
+ *     <button type="submit" name="FooBar">
+ *   </form>
+ */
+
+session_start();
+
+// Generate new token for the session
+if (empty($_SESSION['token'])) {
+    $_SESSION['token'] = bin2hex(random_bytes(32));
+}
+
+// Check if the request is a POST
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+	
+	// Validate token
+    if (hash_equals($_SESSION['token'], $_POST['token'])) {
+         // Everything okay
+    } else {
+		// Token does not match: Redirect to self (GET)
+		header('Location: '.$_SERVER['PHP_SELF']);
+		die();
+    }
+}
+
+$CSRF = '<input type="hidden" name="token" value="' . $_SESSION['token'] . '">';
+
+?>

--- a/other/csrf_handler.php
+++ b/other/csrf_handler.php
@@ -29,9 +29,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (hash_equals($_SESSION['token'], $_POST['token'])) {
          // Everything okay
     } else {
-		// Token does not match: Redirect to self (GET)
-		header('Location: '.$_SERVER['PHP_SELF']);
-		die();
+        // Token does not match: Redirect to self (GET)
+        $phpSelf = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        header('Location: '.$phpSelf);
+        die();
     }
 }
 

--- a/stats/assign_groups.php
+++ b/stats/assign_groups.php
@@ -4,6 +4,7 @@ session_start();
 require_once('../other/config.php');
 require_once('../other/session.php');
 require_once('../other/load_addons_config.php');
+require_once('../other/csrf_handler.php');
 
 $addons_config = load_addons_config($mysqlcon,$lang,$dbname,$timezone,$logpath);
 
@@ -103,6 +104,7 @@ require_once('nav.php');
 					</div>
 				</div>
 				<form class="form-horizontal" name="update" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="row">
 						<div class="col-md-6">
 						</div>

--- a/stats/nav.php
+++ b/stats/nav.php
@@ -1,4 +1,6 @@
 <?PHP
+require_once('../other/csrf_handler.php');
+
 $job_check = $mysqlcon->query("SELECT * FROM $dbname.job_check")->fetchAll(PDO::FETCH_UNIQUE|PDO::FETCH_ASSOC);
 if((time() - $job_check['last_update']['timestamp']) < 259200 && !isset($_SESSION[$rspathhex.'upinfomsg'])) {
 	if(!isset($err_msg)) {
@@ -6,6 +8,7 @@ if((time() - $job_check['last_update']['timestamp']) < 259200 && !isset($_SESSIO
 		$_SESSION[$rspathhex.'upinfomsg'] = 1;
 	}
 }
+
 ?>
 <!DOCTYPE html>
 <html lang="<?PHP echo $language; ?>">
@@ -56,6 +59,7 @@ if((time() - $job_check['last_update']['timestamp']) < 259200 && !isset($_SESSIO
 				</div>
 				<div class="modal-footer">
 					<form method="post">
+							<?php echo $CSRF; ?>
 							<button class="btn btn-primary" type="submit" name="refresh"><?PHP echo $lang['stnv0006']; ?></button>
 							<button type="button" class="btn btn-default" data-dismiss="modal"><?PHP echo $lang['stnv0002']; ?></button>
 					</form>
@@ -192,6 +196,7 @@ if((time() - $job_check['last_update']['timestamp']) < 259200 && !isset($_SESSIO
 				</li>
 				<li class="navbar-form navbar-right">
 					<form method="post">
+						<?php echo $CSRF; ?>
 						<div class="form-group">
 							<input class="form-control" type="text" name="usersuche" placeholder="Search"<?PHP if(isset($getstring)) echo ' value="'.$getstring.'"'; ?>>
 						</div>

--- a/stats/verify.php
+++ b/stats/verify.php
@@ -5,6 +5,7 @@ require_once('../other/config.php');
 require_once('../other/phpcommand.php');
 require_once('../other/session.php');
 require_once('../other/load_addons_config.php');
+require_once('../other/csrf_handler.php');
 
 $addons_config = load_addons_config($mysqlcon,$lang,$dbname,$timezone,$logpath);
 
@@ -146,6 +147,7 @@ require_once('nav.php');
 							<div class="row">
 								<div class="col-xs-12">
 									<form name="verify" method="POST">
+										<?php echo $CSRF; ?>
 										<?PHP
 										if($_SESSION[$rspathhex.'connected'] == 0) {
 											$ts3link = '<a href="ts3server://';

--- a/webinterface/addon_assign_groups.php
+++ b/webinterface/addon_assign_groups.php
@@ -3,6 +3,7 @@ session_start();
 
 require_once('../other/config.php');
 require_once('../other/load_addons_config.php');
+require_once('../other/csrf_handler.php');
 
 $addons_config = load_addons_config($mysqlcon,$lang,$dbname,$timezone,$logpath);
 
@@ -73,6 +74,7 @@ if (isset($_POST['update']) && $_SESSION[$rspathhex.'username'] == $webuser && $
 					</div>
 				</div>
 				<form class="form-horizontal" data-toggle="validator" name="update" method="POST">
+				<?php echo $CSRF; ?>
 				<div class="form-horizontal">
 					<div class="row">
 						<div class="col-md-3">

--- a/webinterface/admin.php
+++ b/webinterface/admin.php
@@ -2,6 +2,7 @@
 session_start();
 
 require_once('../other/config.php');
+require_once('../other/csrf_handler.php');
 
 function getclientip() {
 	if (!empty($_SERVER['HTTP_CLIENT_IP']))
@@ -85,6 +86,7 @@ if (isset($_POST['update']) && $_SESSION[$rspathhex.'username'] == $webuser && $
 				</div>
 				<!-- <form id="update" method="POST"></form> -->
 				<form name="post" method="POST">
+				<?php echo $CSRF; ?>
 				<div class="form-horizontal">
 					<div class="row">
 						<div class="col-md-3">

--- a/webinterface/bot.php
+++ b/webinterface/bot.php
@@ -3,6 +3,7 @@ session_start();
 
 require_once('../other/config.php');
 require_once('../other/phpcommand.php');
+require_once('../other/csrf_handler.php');
 
 function getclientip() {
 	if (!empty($_SERVER['HTTP_CLIENT_IP']))
@@ -245,6 +246,7 @@ if($ts['host'] == NULL || $ts['query'] == NULL || $ts['voice'] == NULL || $ts['u
 					</div>
 				</div>
 				<form class="form-horizontal" name="start" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="row">&nbsp;</div>
 					<div class="row">
 						<div class="text-center">
@@ -256,6 +258,7 @@ if($ts['host'] == NULL || $ts['query'] == NULL || $ts['voice'] == NULL || $ts['u
 					<div class="row">&nbsp;</div>
 				</form>
 				<form class="form-horizontal" name="stop" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="row">&nbsp;</div>
 					<div class="row">
 						<div class="text-center">
@@ -267,6 +270,7 @@ if($ts['host'] == NULL || $ts['query'] == NULL || $ts['voice'] == NULL || $ts['u
 					<div class="row">&nbsp;</div>
 				</form>
 				<form class="form-horizontal" name="restart" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="row">&nbsp;</div>
 					<div class="row">
 						<div class="text-center">
@@ -285,6 +289,7 @@ if($ts['host'] == NULL || $ts['query'] == NULL || $ts['voice'] == NULL || $ts['u
 						</h4>
 					</div>
 					<form class="form-horizontal" name="logfilter" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="col-lg-2">
 						<div class="col-sm-12">
 							<?PHP if($filter2!=NULL) { ?>

--- a/webinterface/changepassword.php
+++ b/webinterface/changepassword.php
@@ -3,6 +3,7 @@ session_start();
 
 require_once('../other/config.php');
 require_once('../other/phpcommand.php');
+require_once('../other/csrf_handler.php');
 
 function enter_logfile($logpath,$timezone,$loglevel,$logtext) {
 	$file = $logpath.'ranksystem.log';
@@ -96,6 +97,7 @@ if (isset($_POST['changepw']) && $_SESSION[$rspathhex.'username'] == $webuser &&
 							<div class="row">
 								<div class="col-xs-12">
 									<form id="resetForm" method="POST">
+										<?php echo $CSRF; ?>
 										<div class="form-group">
 											<label for="password" class="control-label"><?PHP echo $lang['pass3']; ?>:</label>
 											<div class="input-group-justified">

--- a/webinterface/core.php
+++ b/webinterface/core.php
@@ -2,6 +2,7 @@
 session_start();
 
 require_once('../other/config.php');
+require_once('../other/csrf_handler.php');
 
 function getclientip() {
 	if (!empty($_SERVER['HTTP_CLIENT_IP']))
@@ -129,6 +130,7 @@ if (isset($_POST['update']) && $_SESSION[$rspathhex.'username'] == $webuser && $
 					</div>
 				</div>
 				<form class="form-horizontal" data-toggle="validator" name="update" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="row">
 						<div class="col-md-6">
 							<div class="form-group">

--- a/webinterface/db.php
+++ b/webinterface/db.php
@@ -2,6 +2,7 @@
 session_start();
 
 require_once('../other/config.php');
+require_once('../other/csrf_handler.php');
 
 function getclientip() {
 	if (!empty($_SERVER['HTTP_CLIENT_IP']))
@@ -77,6 +78,7 @@ $db[\'dbname\']="'.$_POST['dbname'].'";
 					</div>
 				</div>
 				<form class="form-horizontal" name="update" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="row">
 						<div class="col-md-3">
 						</div>

--- a/webinterface/index.php
+++ b/webinterface/index.php
@@ -3,6 +3,7 @@ session_start();
 
 require_once('../other/config.php');
 require_once('../other/phpcommand.php');
+require_once('../other/csrf_handler.php');
 
 function enter_logfile($logpath,$timezone,$loglevel,$logtext) {
 	$file = $logpath.'ranksystem.log';
@@ -105,6 +106,7 @@ require_once('nav.php');
 							<div class="row">
 								<div class="col-xs-12">
 									<form id="loginForm" method="POST">
+										<?php echo $CSRF; ?>
 										<div class="form-group">
 											<label for="username" class="control-label"><?PHP echo $lang['user']; ?>:</label>
 											<div class="input-group">

--- a/webinterface/msg.php
+++ b/webinterface/msg.php
@@ -2,6 +2,7 @@
 session_start();
 
 require_once('../other/config.php');
+require_once('../other/csrf_handler.php');
 
 function getclientip() {
 	if (!empty($_SERVER['HTTP_CLIENT_IP']))
@@ -67,6 +68,7 @@ if (isset($_POST['update']) && $_SESSION[$rspathhex.'username'] == $webuser && $
 					</div>
 				</div>
 				<form class="form-horizontal" name="update" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="row">
 						<div class="col-md-6">
 							<div class="panel panel-default">

--- a/webinterface/nav.php
+++ b/webinterface/nav.php
@@ -70,6 +70,7 @@ if((time() - $job_check['last_update']['timestamp']) < 259200 && !isset($_SESSIO
 				</li>
 				<li>
 					<form class="navbar-form navbar-center" method="post">
+						<?php echo $CSRF; ?>
 						<div class="form-group">
 							<button type="submit" name="logout" class="btn btn-primary"><?PHP echo $lang['wilogout']; ?>&nbsp;<span class="glyphicon glyphicon-log-out" aria-hidden="true"></span></button>
 						</div>

--- a/webinterface/other.php
+++ b/webinterface/other.php
@@ -2,6 +2,7 @@
 session_start();
 
 require_once('../other/config.php');
+require_once('../other/csrf_handler.php');
 
 function getclientip() {
 	if (!empty($_SERVER['HTTP_CLIENT_IP']))
@@ -62,6 +63,7 @@ if (isset($_POST['update']) && $_SESSION[$rspathhex.'username'] == $webuser && $
 					</div>
 				</div>
 				<form class="form-horizontal" data-toggle="validator" name="update" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="row">
 						<div class="col-md-6">
 							<div class="form-group">

--- a/webinterface/resetpassword.php
+++ b/webinterface/resetpassword.php
@@ -3,6 +3,7 @@ session_start();
 
 require_once('../other/config.php');
 require_once('../other/phpcommand.php');
+require_once('../other/csrf_handler.php');
 
 function enter_logfile($logpath,$timezone,$loglevel,$logtext) {
 	$file = $logpath.'ranksystem.log';
@@ -134,6 +135,7 @@ require_once('nav.php');
 							<div class="row">
 								<div class="col-xs-12">
 									<form id="resetForm" method="POST">
+										<?php echo $CSRF; ?>
 										<p><?PHP echo $lang['wirtpw8']; ?></p>
 										<p><?PHP echo $lang['wirtpw9']; ?>
 											<ul>

--- a/webinterface/stats.php
+++ b/webinterface/stats.php
@@ -2,6 +2,7 @@
 session_start();
 
 require_once('../other/config.php');
+require_once('../other/csrf_handler.php');
 
 function getclientip() {
 	if (!empty($_SERVER['HTTP_CLIENT_IP']))
@@ -70,6 +71,7 @@ if (isset($_POST['update']) && $_SESSION[$rspathhex.'username'] == $webuser && $
 					</div>
 				</div>
 				<form class="form-horizontal" name="update" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="row">
 						<div class="col-md-6">
 							<div class="panel panel-default">

--- a/webinterface/ts.php
+++ b/webinterface/ts.php
@@ -2,6 +2,7 @@
 session_start();
 
 require_once('../other/config.php');
+require_once('../other/csrf_handler.php');
 
 function getclientip() {
 	if (!empty($_SERVER['HTTP_CLIENT_IP']))
@@ -70,6 +71,7 @@ if (isset($_POST['update']) && $_SESSION[$rspathhex.'username'] == $webuser && $
 					</div>
 				</div>
 				<form class="form-horizontal" data-toggle="validator" name="update" method="POST">
+					<?php echo $CSRF; ?>
 					<div class="row">
 						<div class="col-md-6">
 							<div class="panel panel-default">


### PR DESCRIPTION
Bezüglich #450 habe ich hier die CSRF Protection vollständig implementiert.

Bei jeder PHP Datei, deren Body ein oder mehrere POST-Forms enthält, wird der `csrf_handler.php` eingebunden. In jeder Form wird dann ein Token-Feld versteckt:
```html
<?php require_once('../other/csrf_handler.php'); ?>
<!-- ... -->
<form method="POST">
   <?php echo $CSRF; ?>
   <button type="submit" name="FooBar">
</form>
```
Alle veränderten Dateien und der Mechanismus selbst wurden getestet. Ist das CSRF Token fehlerhaft oder die PHP Session ausgelaufen, so wird die Seite "neu geladen":
```php
header('Location: '.$_SERVER['PHP_SELF']);
die();
```

Falls etwas unvollständig ist oder sonst nicht passt einfach schreiben. Dann kann ich weitere Commits an diesen Pull Request anhängen. LG