### PR TITLE
Fix reflected XSS in bot.php

### DIFF
--- a/webinterface/bot.php
+++ b/webinterface/bot.php
@@ -129,7 +129,7 @@ if(isset($_POST['logfilter']) && in_array('debug', $_POST['logfilter'])) {
 	$inactivefilter .= "DEBUG,";
 }
 if(isset($_POST['logfilter'][0])) {
-	$filter2 = $_POST['logfilter'][0];
+	$filter2 = htmlspecialchars($_POST['logfilter'][0]);
 	$_SESSION[$rspathhex.'logfilter2'] = $filter2;
 }
 


### PR DESCRIPTION
Bezüglich #450:
Hier ist der Fix, um das reflektierte XSS in webinterface/bot.php zu verhindern.