### PR TITLE
Added admin_addtime and user_iphash to backup

### DIFF
--- a/jobs/update_rs.php
+++ b/jobs/update_rs.php
@@ -5,7 +5,7 @@ function update_rs($mysqlcon,$lang,$dbname,$logpath,$timezone,$newversion,$phpco
 	enter_logfile($logpath,$timezone,4,"    Backup the database due cloning tables...",$norotate);
 	$countbackuperr = 0;
 	
-	$tables = array('addons_config','addon_assign_groups','config','groups','job_check','server_usage','stats_nations','stats_platforms','stats_server','stats_user','stats_versions','user','user_snapshot');
+	$tables = array('addons_config','addon_assign_groups','admin_addtime','config','groups','job_check','server_usage','stats_nations','stats_platforms','stats_server','stats_user','stats_versions','user','user_iphash','user_snapshot');
 	
 	foreach ($tables as $table) {
 		if($mysqlcon->query("SELECT 1 FROM `$dbname`.`bak_$table` LIMIT 1") !== false) {


### PR DESCRIPTION
Wie der Titel sagt, war ich mal so frei beide (neuen) Tabellen im Updater einzupflegen für ein Backup. Bei IPHash bin ich mir nicht sicher obs was nutzt, aber lieber mehr als zu wenig sichern.