### PR TITLE
Reset CURL VERIFYPEER and VERIFYHOST to default 

### DIFF
--- a/jobs/calc_serverstats.php
+++ b/jobs/calc_serverstats.php
@@ -407,8 +407,6 @@ function calc_serverstats($ts3,$mysqlcon,&$cfg,$dbname,$dbtype,$serverinfo,&$db_
 				$cfg['temp_db_version']
 			);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST,false);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER,false);
 			curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
 			curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
 			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);


### PR DESCRIPTION
I think I do not have to explain that much with this PR, it is closing an obvious vulnerability regarding MITM attacks between the rank system and the update server.

I consider the severity as rather low.

See https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html
and https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html
for details.

Re-enabling those check does not affect the rank system as long as the update server _ts-n.net_ keeps it's certificate valid. This is required anyways, e.g. when the rank system downloads the update ZIP.