### PR TITLE
Compare the API key with a timing safe function

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -14,7 +14,7 @@ header("Content-Type: application/json; charset=UTF-8");
 if (isset($_GET['apikey'])) {
 	$matchkey = 0;
 	foreach($cfg['stats_api_keys'] as $apikey => $desc) {
-		if ($apikey == $_GET['apikey']) $matchkey = 1;
+		if (hash_equals($apikey, $_GET['apikey'])) $matchkey = 1;
 	}
 	if ($matchkey == 0) {
 		$json = array(


### PR DESCRIPTION
Protect API key comparison from timing attacks. See https://www.php.net/manual/en/function.hash-equals.php for more information. The function is available from PHP 5 >= 5.6.0.