### PR TITLE
Correct the webinterface HTTPS warning

### DIFF
--- a/other/_functions.php
+++ b/other/_functions.php
@@ -55,33 +55,39 @@ function enter_logfile($cfg,$loglevel,$logtext,$norotate = false) {
 	}
 }
 
-function error_handling($msg,$type = NULL) {
+function error_handling_str_builder($msg,$type = NULL) {
+    $string = '';
 	if(strstr($type, '#') && strstr($msg, '#####')) {
 		$type_arr = explode('#', $type);
 		$msg_arr = explode('#####', $msg);
 		$cnt = 0;
-		
+
 		foreach($msg_arr as $msg) {
 			switch ($type_arr[$cnt]) {
-				case NULL: echo '<div class="alert alert-success alert-dismissible">'; break;
-				case 0: echo '<div class="alert alert-success alert-dismissible">'; break;
-				case 1: echo '<div class="alert alert-info alert-dismissible">'; break;
-				case 2: echo '<div class="alert alert-warning alert-dismissible">'; break;
-				case 3: echo '<div class="alert alert-danger alert-dismissible">'; break;
+				case NULL: $string .= '<div class="alert alert-success alert-dismissible">'; break;
+				case 0: $string .= '<div class="alert alert-success alert-dismissible">'; break;
+				case 1: $string .= '<div class="alert alert-info alert-dismissible">'; break;
+				case 2: $string .= '<div class="alert alert-warning alert-dismissible">'; break;
+				case 3: $string .= '<div class="alert alert-danger alert-dismissible">'; break;
 			}
-			echo '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>',$msg_arr[$cnt],'</div>';
+			$string .= '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>' . $msg_arr[$cnt] . '</div>';
 			$cnt++;
 		}
 	} else {
 		switch ($type) {
-			case NULL: echo '<div class="alert alert-success alert-dismissible">'; break;
-			case 0: echo '<div class="alert alert-success alert-dismissible">'; break;
-			case 1: echo '<div class="alert alert-info alert-dismissible">'; break;
-			case 2: echo '<div class="alert alert-warning alert-dismissible">'; break;
-			case 3: echo '<div class="alert alert-danger alert-dismissible">'; break;
+			case NULL: $string .= '<div class="alert alert-success alert-dismissible">'; break;
+			case 0: $string .= '<div class="alert alert-success alert-dismissible">'; break;
+			case 1: $string .= '<div class="alert alert-info alert-dismissible">'; break;
+			case 2: $string .= '<div class="alert alert-warning alert-dismissible">'; break;
+			case 3: $string .= '<div class="alert alert-danger alert-dismissible">'; break;
 		}
-		echo '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>',$msg,'</div>';
+		$string .= '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>' . $msg . '</div>';
 	}
+	return $string;
+}
+
+function error_handling($msg,$type = NULL) {
+	echo error_handling_str_builder($msg,$type);
 }
 
 function getclientip() {

--- a/webinterface/_nav.php
+++ b/webinterface/_nav.php
@@ -269,8 +269,12 @@ if($cfg['webinterface_admin_client_unique_id_list'] == NULL && isset($_SESSION[$
 	$err_msg = $lang['winav11']; $err_lvl = 2;
 }
 
-if((!isset($_SERVER['HTTPS']) || isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != "on") && !isset($err_msg) && basename($_SERVER['SCRIPT_NAME']) == "index.php") {
+$js_test_https = '';
+if(!isset($err_msg) && basename($_SERVER['SCRIPT_NAME']) == "index.php") {
 	$host = "<a href=\"https://".$_SERVER['HTTP_HOST'].rtrim(dirname($_SERVER['PHP_SELF']), '/\\')."\">";
-	$err_msg = sprintf($lang['winav10'], $host,'</a>!<br>', '<br>'); $err_lvl = 2;
+	$msg = sprintf($lang['winav10'], $host,'</a>!<br>', '<br>');
+	$js_test_https  = '<script> if (location.protocol !== \'https:\') {';
+	$js_test_https .= 'document.write(\'' . error_handling_str_builder($msg, 2) . '\')';
+	$js_test_https .= '} </script>';
 }
 ?>

--- a/webinterface/index.php
+++ b/webinterface/index.php
@@ -102,6 +102,7 @@ try {
 	?>
 			<div id="page-wrapper">
 	<?PHP if(isset($err_msg)) error_handling($err_msg, $err_lvl); ?>
+	<?PHP echo $js_test_https ?>
 				<div class="container-fluid">
 					<div id="login-overlay" class="modal-dialog">
 						<div class="modal-content">


### PR DESCRIPTION
The current HTTPS detection does not work with a load balancer / proxy between the rank system and the client. Therefore the detection is moved to the client side (Javascript).