### PR TITLE
Reduce necessary database privileges

### DIFF
--- a/install.php
+++ b/install.php
@@ -79,18 +79,8 @@ $db[\'dbname\']=\''.$dbname.'\';
 		$err_lvl = 2;
 	} else {
 		$count = 1;
-		$stmt = $mysqlcon->query('SHOW DATABASES');
-		while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-			if ($row['Database'] == $dbname) {
-				$dbExists = true;
-				break;
-			}
-		}
-		if ($dbExists) {
-			if(($mysqlcon->exec("DROP DATABASE `$dbname`")) === false) { }
-		}
-		
-		if($mysqlcon->exec("CREATE DATABASE `$dbname`") === false) {
+
+		if($mysqlcon->exec("CREATE DATABASE IF NOT EXISTS `$dbname`") === false) {
 			$err_msg .= $lang['isntwidbmsg'].$mysqlcon->errorCode()." ".print_r($mysqlcon->errorInfo(), true).'<br>'; $err_lvl = 2;
 			$count++;
 		}


### PR DESCRIPTION
- Avoid the usage of "SHOW DATABASES" as this requires global privileges, which a restricted database user will not have in best case. The application should not be potentially able to see other databases on the host.
- Avoid the usage of "DROP DATABASE" as an application should never delete itself. This also ensures, that the application does not accidently delete all data.
- "CREATE DATABASE" only if it not exists yet. This ensures, that the application can create the database, if it does not exist yet, but it will not fail, if it already exists.
- If the database already has the necessary tables, the following SQL statements will fail, so the "if database exists" check is not necessary.